### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides seamless access to Contentful's Delivery API through AI assistants. Query and retrieve content entries, assets, and content types using natural language.
 
+<a href="https://glama.ai/mcp/servers/v84ui258n5">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/v84ui258n5/badge" alt="Contentful Delivery Server MCP server" />
+</a>
+
 ## Quick Start
 
 Install the package in your project:


### PR DESCRIPTION
This PR adds a badge for the [Contentful Delivery MCP Server](https://glama.ai/mcp/servers/v84ui258n5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/v84ui258n5">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/v84ui258n5/badge" alt="Contentful Delivery Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.